### PR TITLE
header takes width 100%

### DIFF
--- a/_sass/custom.scss
+++ b/_sass/custom.scss
@@ -1,0 +1,3 @@
+header div.wrapper {
+    max-width: none;
+}

--- a/assets/main.scss
+++ b/assets/main.scss
@@ -37,3 +37,4 @@ $on-laptop:        800px;
 
 // Import partials from the `minima` theme.
 @import "minima";
+@import "custom"


### PR DESCRIPTION
Con estos cambios el header cogerá el 100% del ancho.
Lo que he hecho ha sido:
- Crear un nuevo fichero /_sass/custom.scss -> En él puedes añadir código css extra a partir de ahora
- En ese mismo fichero he añadido una regla css para el menú del header, especificando que no tenga ancho máximo (max-width: none;)
- En /assets/main.scss he importado el fichero /_sass/custom.scss para que funcione el código del nuevo archivo custom.scss